### PR TITLE
254/Update for cypress run command script

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -2,7 +2,7 @@ const SCRIPTS = {
   CYPRESS: [
     {
       name: "cypress",
-      command: "npx cypress open",
+      command: "npx cypress run",
     },
   ],
   JEST: [


### PR DESCRIPTION
Issue: #254 
Updated `npx cypress open` to `npx cypress run`.
Cypress test will execute on bash. 
> Note: command "npm cypress"